### PR TITLE
Support for spaces in the names of `ItemDefinition`'s

### DIFF
--- a/api-check-ignore.xml
+++ b/api-check-ignore.xml
@@ -1,0 +1,40 @@
+<differences>
+    <!-- ignore errors originating in changes to compiler generated anonymous functions -->
+    <difference>
+        <className>org/camunda/dmn/**</className>
+        <!-- method removed -->
+        <differenceType>7002</differenceType>
+        <method>*$anonfun*</method>
+    </difference>
+    <difference>
+        <className>org/camunda/dmn/**</className>
+        <!-- num method params -->
+        <differenceType>7004</differenceType>
+        <method>*$anonfun*</method>
+        <from>*</from>
+        <to>*</to>
+    </difference>
+    <difference>
+        <className>org/camunda/dmn/**</className>
+        <!-- method param type -->
+        <differenceType>7005</differenceType>
+        <method>*$anonfun*</method>
+        <!--don't care what the type has changed to-->
+        <from>*</from>
+        <to>*</to>
+    </difference>
+    <difference>
+        <className>org/camunda/dmn/**</className>
+        <!-- return type -->
+        <differenceType>7006</differenceType>
+        <method>*$anonfun*</method>
+        <from>*</from>
+        <to>*</to>
+    </difference>
+    <difference>
+        <className>org/camunda/dmn/**</className>
+        <!-- method added -->
+        <differenceType>7011</differenceType>
+        <method>*$anonfun*</method>
+    </difference>
+</differences>

--- a/pom.xml
+++ b/pom.xml
@@ -267,6 +267,8 @@
             <exclude>org/camunda/dmn/**/*$</exclude>
             <exclude>org/camunda/dmn/**/*$anonfun*</exclude>
           </excludes>
+          <!-- Specifically ignore functions that may have changed -->
+          <ignoredDifferencesFile>api-check-ignore.xml</ignoredDifferencesFile>
         </configuration>
       </plugin>
 

--- a/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
+++ b/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
@@ -19,7 +19,21 @@ import java.io.InputStream
 import org.camunda.dmn.logger
 import org.camunda.bpm.model.dmn._
 import org.camunda.bpm.model.dmn.impl.DmnModelConstants
-import org.camunda.bpm.model.dmn.instance.{BusinessKnowledgeModel, Column, Context, Decision, DecisionTable, Expression, FunctionDefinition, InformationItem, Invocation, ItemDefinition, LiteralExpression, Relation, UnaryTests, List => DmnList}
+import org.camunda.bpm.model.dmn.instance.{
+  BusinessKnowledgeModel,
+  Column,
+  Context,
+  Decision,
+  DecisionTable,
+  Expression,
+  FunctionDefinition,
+  InformationItem,
+  Invocation,
+  ItemDefinition,
+  LiteralExpression,
+  Relation,
+  UnaryTests,
+  List => DmnList}
 import org.camunda.dmn.DmnEngine.{Configuration, Failure}
 import org.camunda.feel
 

--- a/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
+++ b/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
@@ -556,10 +556,8 @@ class DmnParser(
 
   private def getNamesToEscape(model: DmnModelInstance): Iterable[String] = {
 
-    val elementTypes: List[Class[_ >: InformationItem with ItemDefinition <: NamedElement]] =
-      List(classOf[InformationItem], classOf[ItemDefinition])
-
-    val names = elementTypes.flatMap(elementType => model.getModelElementsByType(elementType).asScala)
+    val names = Seq(classOf[InformationItem], classOf[ItemDefinition]).flatMap(elementType =>
+      model.getModelElementsByType(elementType).asScala)
       .filterNot(classOf[Column].isInstance(_))
       .map(_.getName)
 

--- a/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
+++ b/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
@@ -31,6 +31,7 @@ import org.camunda.bpm.model.dmn.instance.{
   Invocation,
   ItemDefinition,
   LiteralExpression,
+  NamedElement,
   Relation,
   UnaryTests,
   List => DmnList}
@@ -554,7 +555,7 @@ class DmnParser(
 
   private def getNamesToEscape(model: DmnModelInstance): Iterable[String] = {
 
-    val elementTypes =
+    val elementTypes: List[Class[_ >: InformationItem with ItemDefinition <: NamedElement]] =
       List(classOf[InformationItem], classOf[ItemDefinition])
 
     val names = elementTypes.flatMap(elementType =>

--- a/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
+++ b/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
@@ -34,7 +34,8 @@ import org.camunda.bpm.model.dmn.instance.{
   NamedElement,
   Relation,
   UnaryTests,
-  List => DmnList}
+  List => DmnList
+}
 import org.camunda.dmn.DmnEngine.{Configuration, Failure}
 import org.camunda.feel
 

--- a/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
+++ b/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
@@ -31,7 +31,6 @@ import org.camunda.bpm.model.dmn.instance.{
   Invocation,
   ItemDefinition,
   LiteralExpression,
-  NamedElement,
   Relation,
   UnaryTests,
   List => DmnList

--- a/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
+++ b/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
@@ -19,21 +19,7 @@ import java.io.InputStream
 import org.camunda.dmn.logger
 import org.camunda.bpm.model.dmn._
 import org.camunda.bpm.model.dmn.impl.DmnModelConstants
-import org.camunda.bpm.model.dmn.instance.{
-  BusinessKnowledgeModel,
-  Column,
-  Context,
-  Decision,
-  DecisionTable,
-  Expression,
-  FunctionDefinition,
-  InformationItem,
-  Invocation,
-  LiteralExpression,
-  Relation,
-  UnaryTests,
-  List => DmnList
-}
+import org.camunda.bpm.model.dmn.instance.{BusinessKnowledgeModel, Column, Context, Decision, DecisionTable, Expression, FunctionDefinition, InformationItem, Invocation, ItemDefinition, LiteralExpression, Relation, UnaryTests, List => DmnList}
 import org.camunda.dmn.DmnEngine.{Configuration, Failure}
 import org.camunda.feel
 
@@ -554,9 +540,11 @@ class DmnParser(
 
   private def getNamesToEscape(model: DmnModelInstance): Iterable[String] = {
 
-    val names = model
-      .getModelElementsByType(classOf[InformationItem])
-      .asScala
+    val elementTypes =
+      List(classOf[InformationItem], classOf[ItemDefinition])
+
+    val names = elementTypes.flatMap(elementType =>
+        model.getModelElementsByType(elementType).asScala)
       .filterNot(classOf[Column].isInstance(_))
       .map(_.getName)
 

--- a/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
+++ b/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
@@ -558,8 +558,7 @@ class DmnParser(
     val elementTypes: List[Class[_ >: InformationItem with ItemDefinition <: NamedElement]] =
       List(classOf[InformationItem], classOf[ItemDefinition])
 
-    val names = elementTypes.flatMap(elementType =>
-        model.getModelElementsByType(elementType).asScala)
+    val names = elementTypes.flatMap(elementType => model.getModelElementsByType(elementType).asScala)
       .filterNot(classOf[Column].isInstance(_))
       .map(_.getName)
 

--- a/src/test/resources/config/decision_with_spaces_in_item_definition_and_item_component.dmn
+++ b/src/test/resources/config/decision_with_spaces_in_item_definition_and_item_component.dmn
@@ -25,7 +25,7 @@
                 <!-- First Name is escaped via the fact it is defined as a variable within this context -->
                 <!-- Last Name is escaped via the Item Definition / Item Component reference -->
                 <literalExpression>
-                    <text>"Hello " + First Name + " " + Last Name</text>
+                    <text>"Hello " + First Name + " " + greetingData.Last Name</text>
                 </literalExpression>
             </contextEntry>
         </context>

--- a/src/test/resources/config/decision_with_spaces_in_item_definition_and_item_component.dmn
+++ b/src/test/resources/config/decision_with_spaces_in_item_definition_and_item_component.dmn
@@ -33,7 +33,7 @@
 
     <inputData id="greetingDataInput" name="greetingData">
         <extensionElements />
-        <variable id="greetingDataVariable" name="greetingData" typeRef="GreetingData" />
+        <variable id="greetingDataVariable" name="greetingData" typeRef="Greeting Data" />
     </inputData>
 
 </definitions>

--- a/src/test/resources/config/decision_with_spaces_in_item_definition_and_item_component.dmn
+++ b/src/test/resources/config/decision_with_spaces_in_item_definition_and_item_component.dmn
@@ -23,7 +23,7 @@
             </contextEntry>
             <contextEntry>
                 <!-- First Name is escaped via the fact it is defined as a variable within this context -->
-                <!-- Last Name is escaped via the Item Definition -->
+                <!-- Last Name is escaped via the Item Definition / Item Component reference -->
                 <literalExpression>
                     <text>"Hello " + First Name + " " + Last Name</text>
                 </literalExpression>

--- a/src/test/resources/config/decision_with_spaces_in_item_definition_and_item_component.dmn
+++ b/src/test/resources/config/decision_with_spaces_in_item_definition_and_item_component.dmn
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="_0001-input-data-string" name="0001-input-data-string"
+             namespace="https://github.com/agilepro/dmn-tck"
+             xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd"
+             xmlns:feel="http://www.omg.org/spec/FEEL/20140401">
+
+    <itemDefinition id="greetingData" name="Greeting Data" isCollection="false">
+        <itemComponent id="firstName" name="First Name" isCollection="false">
+            <typeRef>string</typeRef>
+        </itemComponent>
+        <itemComponent id="lastName" name="Last Name" isCollection="false">
+            <typeRef>string</typeRef>
+        </itemComponent>
+    </itemDefinition>
+    
+    <decision name="GreetingMessage" id="greeting">
+        <informationRequirement>
+            <requiredInput href="#greetingDataVariable" />
+        </informationRequirement>
+        <context>
+            <contextEntry>
+                <variable name="First Name"/>
+                <literalExpression>
+                    <text>name</text>
+                </literalExpression>
+            </contextEntry>
+            <contextEntry>
+                <literalExpression>
+                    <text>"Hello " + First Name</text>
+                </literalExpression>
+            </contextEntry>
+        </context>
+    </decision>
+
+    <inputData id="greetingDataInput" name="greetingData">
+        <extensionElements />
+        <variable id="greetingDataVariable" name="greetingData" typeRef="Greeting Data" />
+    </inputData>
+
+</definitions>

--- a/src/test/resources/config/decision_with_spaces_in_item_definition_and_item_component.dmn
+++ b/src/test/resources/config/decision_with_spaces_in_item_definition_and_item_component.dmn
@@ -5,14 +5,11 @@
              xmlns:feel="http://www.omg.org/spec/FEEL/20140401">
 
     <itemDefinition id="greetingData" name="Greeting Data" isCollection="false">
-        <itemComponent id="firstName" name="First Name" isCollection="false">
-            <typeRef>string</typeRef>
-        </itemComponent>
         <itemComponent id="lastName" name="Last Name" isCollection="false">
             <typeRef>string</typeRef>
         </itemComponent>
     </itemDefinition>
-    
+
     <decision name="GreetingMessage" id="greeting">
         <informationRequirement>
             <requiredInput href="#greetingDataVariable" />
@@ -25,8 +22,10 @@
                 </literalExpression>
             </contextEntry>
             <contextEntry>
+                <!-- First Name is escaped via the fact it is defined as a variable within this context -->
+                <!-- Last Name is escaped via the Item Definition -->
                 <literalExpression>
-                    <text>"Hello " + First Name</text>
+                    <text>"Hello " + First Name + " " + Last Name</text>
                 </literalExpression>
             </contextEntry>
         </context>
@@ -34,7 +33,7 @@
 
     <inputData id="greetingDataInput" name="greetingData">
         <extensionElements />
-        <variable id="greetingDataVariable" name="greetingData" typeRef="Greeting Data" />
+        <variable id="greetingDataVariable" name="greetingData" typeRef="GreetingData" />
     </inputData>
 
 </definitions>

--- a/src/test/resources/config/decision_with_spaces_in_item_definition_and_item_component.dmn
+++ b/src/test/resources/config/decision_with_spaces_in_item_definition_and_item_component.dmn
@@ -33,7 +33,7 @@
 
     <inputData id="greetingDataInput" name="greetingData">
         <extensionElements />
-        <variable id="greetingDataVariable" name="greetingData" typeRef="Greeting Data" />
+        <variable id="greetingDataVariable" name="greetingData" typeRef="greetingData" />
     </inputData>
 
 </definitions>

--- a/src/test/scala/org/camunda/dmn/DmnEngineConfigurationTest.scala
+++ b/src/test/scala/org/camunda/dmn/DmnEngineConfigurationTest.scala
@@ -71,7 +71,7 @@ class DmnEngineConfigurationTest extends AnyFlatSpec with Matchers {
     result.map(_.value should be("Hello DMN"))
   }
 
-  "A DMN engine with escaped names" should "evaluate a decision with spaces in item definitions and item components" in {
+  it should "evaluate a decision with spaces in item definitions and item components" in {
 
     val result = engineWithEscapeNames
       .parse(decisionWithSpacesInItemDefinitionAndItemComponents)

--- a/src/test/scala/org/camunda/dmn/DmnEngineConfigurationTest.scala
+++ b/src/test/scala/org/camunda/dmn/DmnEngineConfigurationTest.scala
@@ -75,7 +75,7 @@ class DmnEngineConfigurationTest extends AnyFlatSpec with Matchers {
 
     val result = engineWithEscapeNames
       .parse(decisionWithSpacesInItemDefinitionAndItemComponents)
-      .flatMap(engineWithEscapeNames.eval(_, "greeting", Map("name" -> "Luke", "Last Name" -> "Skywalker")))
+      .flatMap(engineWithEscapeNames.eval(_, "greeting", Map("name" -> "Luke", "greetingData" -> Map("Last Name" -> "Skywalker"))))
 
     result.isRight should be(true)
     result.map(_.value should be("Hello Luke Skywalker"))

--- a/src/test/scala/org/camunda/dmn/DmnEngineConfigurationTest.scala
+++ b/src/test/scala/org/camunda/dmn/DmnEngineConfigurationTest.scala
@@ -46,6 +46,8 @@ class DmnEngineConfigurationTest extends AnyFlatSpec with Matchers {
 
   private def decisionWithSpaces =
     getClass.getResourceAsStream("/config/decision_with_spaces.dmn")
+  private def decisionWithSpacesInItemDefinitionAndItemComponents =
+    getClass.getResourceAsStream("/config/decision_with_spaces_in_item_definition_and_item_component.dmn")
   private def decisionWithDash =
     getClass.getResourceAsStream("/config/decision_with_dash.dmn")
   private def bkmWithSpacesAndDash =
@@ -63,6 +65,16 @@ class DmnEngineConfigurationTest extends AnyFlatSpec with Matchers {
 
     val result = engineWithEscapeNames
       .parse(decisionWithSpaces)
+      .flatMap(engineWithEscapeNames.eval(_, "greeting", Map("name" -> "DMN")))
+
+    result.isRight should be(true)
+    result.map(_.value should be("Hello DMN"))
+  }
+
+  "A DMN engine with escaped names" should "evaluate a decision with spaces in item definitions and item components" in {
+
+    val result = engineWithEscapeNames
+      .parse(decisionWithSpacesInItemDefinitionAndItemComponents)
       .flatMap(engineWithEscapeNames.eval(_, "greeting", Map("name" -> "DMN")))
 
     result.isRight should be(true)

--- a/src/test/scala/org/camunda/dmn/DmnEngineConfigurationTest.scala
+++ b/src/test/scala/org/camunda/dmn/DmnEngineConfigurationTest.scala
@@ -75,10 +75,10 @@ class DmnEngineConfigurationTest extends AnyFlatSpec with Matchers {
 
     val result = engineWithEscapeNames
       .parse(decisionWithSpacesInItemDefinitionAndItemComponents)
-      .flatMap(engineWithEscapeNames.eval(_, "greeting", Map("name" -> "DMN")))
+      .flatMap(engineWithEscapeNames.eval(_, "greeting", Map("name" -> "Luke", "Last Name" -> "Skywalker")))
 
     result.isRight should be(true)
-    result.map(_.value should be("Hello DMN"))
+    result.map(_.value should be("Hello Luke Skywalker"))
   }
 
   it should "evaluate a decision with dash" in {


### PR DESCRIPTION
## Description

Allows spaces to be used in the names of `ItemDefinition`'s as per the DMN specification. Although `ItemDefinition`'s are not supported by Camunda Modeller, we have a customer need to import DMN models created in third-party DMN modelling tools for execution within the Camunda DMN engine.

See link in the related issues section for more details and context.

## Related issues

#150 