### PR TITLE
fix: Handle the invocation of a non-existing decision

### DIFF
--- a/src/main/scala/org/camunda/dmn/Audit.scala
+++ b/src/main/scala/org/camunda/dmn/Audit.scala
@@ -27,11 +27,7 @@ object Audit {
     def onFailure(log: AuditLog)
   }
 
-  case class AuditLog(dmn: ParsedDmn, entries: List[AuditLogEntry]) {
-
-    val rootEntry = entries.last
-    val requiredEntries = entries.dropRight(1)
-  }
+  case class AuditLog(dmn: ParsedDmn, entries: List[AuditLogEntry])
 
   case class AuditLogEntry(id: String,
                            name: String,

--- a/src/test/scala/org/camunda/dmn/AuditLogTest.scala
+++ b/src/test/scala/org/camunda/dmn/AuditLogTest.scala
@@ -42,13 +42,16 @@ class AuditLogTest extends AnyFlatSpec with Matchers with DecisionTest {
          "discount",
          Map("customer" -> "Business", "orderSize" -> 7))
 
-    auditLog.rootEntry.id should be("discount")
-    auditLog.rootEntry.name should be("Discount")
-    auditLog.rootEntry.decisionLogic shouldBe a[ParsedDecisionTable]
-    auditLog.rootEntry.result shouldBe a[DecisionTableEvaluationResult]
+    auditLog.entries should have size(1)
+
+    val auditLogEntry = auditLog.entries.head
+    auditLogEntry.id should be("discount")
+    auditLogEntry.name should be("Discount")
+    auditLogEntry.decisionLogic shouldBe a[ParsedDecisionTable]
+    auditLogEntry.result shouldBe a[DecisionTableEvaluationResult]
 
     val result =
-      auditLog.rootEntry.result.asInstanceOf[DecisionTableEvaluationResult]
+      auditLogEntry.result.asInstanceOf[DecisionTableEvaluationResult]
     result.inputs.size should be(2)
 
     result.inputs(0).input.id should be("input1")
@@ -64,8 +67,6 @@ class AuditLogTest extends AnyFlatSpec with Matchers with DecisionTest {
     result.matchedRules(0).outputs(0).value should be(ValNumber(0.1))
 
     result.result should be(ValNumber(0.1))
-
-    auditLog.requiredEntries.size should be(0)
   }
 
   it should "contains the result of a decision table if no rule matched" in {
@@ -74,13 +75,16 @@ class AuditLogTest extends AnyFlatSpec with Matchers with DecisionTest {
          "discount",
          Map("customer" -> "Other", "orderSize" -> 7))
 
-    auditLog.rootEntry.id should be("discount")
-    auditLog.rootEntry.name should be("Discount")
-    auditLog.rootEntry.decisionLogic shouldBe a[ParsedDecisionTable]
-    auditLog.rootEntry.result shouldBe a[DecisionTableEvaluationResult]
+    auditLog.entries should have size (1)
+
+    val auditLogEntry = auditLog.entries.head
+    auditLogEntry.id should be("discount")
+    auditLogEntry.name should be("Discount")
+    auditLogEntry.decisionLogic shouldBe a[ParsedDecisionTable]
+    auditLogEntry.result shouldBe a[DecisionTableEvaluationResult]
 
     val result =
-      auditLog.rootEntry.result.asInstanceOf[DecisionTableEvaluationResult]
+      auditLogEntry.result.asInstanceOf[DecisionTableEvaluationResult]
     result.inputs.size should be(2)
 
     result.inputs(0).input.id should be("input1")
@@ -93,8 +97,6 @@ class AuditLogTest extends AnyFlatSpec with Matchers with DecisionTest {
     result.matchedRules.size should be(0)
 
     result.result should be(ValNull)
-
-    auditLog.requiredEntries.size should be(0)
   }
 
   it should "contains the result of a decision table if a failure occurred" in {
@@ -103,13 +105,16 @@ class AuditLogTest extends AnyFlatSpec with Matchers with DecisionTest {
          "discount",
          Map("customer" -> "Business", "orderSize" -> 9))
 
-    auditLog.rootEntry.id should be("discount")
-    auditLog.rootEntry.name should be("Discount")
-    auditLog.rootEntry.decisionLogic shouldBe a[ParsedDecisionTable]
-    auditLog.rootEntry.result shouldBe a[DecisionTableEvaluationResult]
+    auditLog.entries should have size (1)
+
+    val auditLogEntry = auditLog.entries.head
+    auditLogEntry.id should be("discount")
+    auditLogEntry.name should be("Discount")
+    auditLogEntry.decisionLogic shouldBe a[ParsedDecisionTable]
+    auditLogEntry.result shouldBe a[DecisionTableEvaluationResult]
 
     val result =
-      auditLog.rootEntry.result.asInstanceOf[DecisionTableEvaluationResult]
+      auditLogEntry.result.asInstanceOf[DecisionTableEvaluationResult]
     result.inputs.size should be(2)
 
     result.inputs(0).input.id should be("input1")
@@ -126,8 +131,6 @@ class AuditLogTest extends AnyFlatSpec with Matchers with DecisionTest {
 
     result.result should be(ValError(
       "multiple values aren't allowed for UNIQUE hit policy. found: 'List(Map(discount -> ValNumber(0.1)), Map(discount -> ValNumber(0.15)))'"))
-
-    auditLog.requiredEntries.size should be(0)
   }
 
   it should "contains the result of a context" in {
@@ -139,12 +142,15 @@ class AuditLogTest extends AnyFlatSpec with Matchers with DecisionTest {
 
     eval(eligibilityContext, "eligibility", variables)
 
-    auditLog.rootEntry.id should be("eligibility")
-    auditLog.rootEntry.name should be("Eligibility")
-    auditLog.rootEntry.decisionLogic shouldBe a[ParsedContext]
-    auditLog.rootEntry.result shouldBe a[ContextEvaluationResult]
+    auditLog.entries should have size(1)
 
-    val result = auditLog.rootEntry.result.asInstanceOf[ContextEvaluationResult]
+    val auditLogEntry = auditLog.entries.head
+    auditLogEntry.id should be("eligibility")
+    auditLogEntry.name should be("Eligibility")
+    auditLogEntry.decisionLogic shouldBe a[ParsedContext]
+    auditLogEntry.result shouldBe a[ContextEvaluationResult]
+
+    val result = auditLogEntry.result.asInstanceOf[ContextEvaluationResult]
     result.entries.size should be(4)
 
     result.entries("Age") should be(ValNumber(51))
@@ -153,23 +159,22 @@ class AuditLogTest extends AnyFlatSpec with Matchers with DecisionTest {
     result.entries("InstallmentAffordable") should be(ValBoolean(true))
 
     result.result should be(ValString("INELIGIBLE"))
-
-    auditLog.requiredEntries.size should be(0)
   }
 
   it should "contains the result of an expression" in {
 
     eval(greeting, "greeting", Map("name" -> "John"))
 
-    auditLog.rootEntry.id should be("greeting")
-    auditLog.rootEntry.name should be("GreetingMessage")
-    auditLog.rootEntry.decisionLogic shouldBe a[ParsedLiteralExpression]
-    auditLog.rootEntry.result shouldBe a[SingleEvaluationResult]
+    auditLog.entries should have size(1)
 
-    val result = auditLog.rootEntry.result.asInstanceOf[SingleEvaluationResult]
+    val auditLogEntry = auditLog.entries.head
+    auditLogEntry.id should be("greeting")
+    auditLogEntry.name should be("GreetingMessage")
+    auditLogEntry.decisionLogic shouldBe a[ParsedLiteralExpression]
+    auditLogEntry.result shouldBe a[SingleEvaluationResult]
+
+    val result = auditLogEntry.result.asInstanceOf[SingleEvaluationResult]
     result.result should be(ValString("Hello John"))
-
-    auditLog.requiredEntries.size should be(0)
   }
 
   it should "contains the result of a BKM invocation" in {
@@ -178,41 +183,47 @@ class AuditLogTest extends AnyFlatSpec with Matchers with DecisionTest {
          "discount",
          Map("Customer" -> "Business", "OrderSize" -> 7))
 
-    auditLog.rootEntry.id should be("discount")
-    auditLog.rootEntry.name should be("Discount")
-    auditLog.rootEntry.decisionLogic shouldBe a[ParsedInvocation]
-    auditLog.rootEntry.result shouldBe a[SingleEvaluationResult]
+    auditLog.entries should have size(2)
 
-    val result = auditLog.rootEntry.result.asInstanceOf[SingleEvaluationResult]
+    val bkmAuditLogEntry = auditLog.entries.head
+    val rootAuditLogEntry = auditLog.entries.last
+
+    rootAuditLogEntry.id should be("discount")
+    rootAuditLogEntry.name should be("Discount")
+    rootAuditLogEntry.decisionLogic shouldBe a[ParsedInvocation]
+    rootAuditLogEntry.result shouldBe a[SingleEvaluationResult]
+
+    val result = rootAuditLogEntry.result.asInstanceOf[SingleEvaluationResult]
     result.result should be(ValNumber(0.1))
 
-    auditLog.requiredEntries.size should be(1)
-    auditLog.requiredEntries(0).id should be("bkm_discount")
-    auditLog.requiredEntries(0).name should be("Discount table")
-    auditLog.requiredEntries(0).decisionLogic shouldBe a[ParsedDecisionTable]
-    auditLog.requiredEntries(0).result shouldBe a[DecisionTableEvaluationResult]
-    auditLog.requiredEntries(0).result.result should be(ValNumber(0.1))
+    bkmAuditLogEntry.id should be("bkm_discount")
+    bkmAuditLogEntry.name should be("Discount table")
+    bkmAuditLogEntry.decisionLogic shouldBe a[ParsedDecisionTable]
+    bkmAuditLogEntry.result shouldBe a[DecisionTableEvaluationResult]
+    bkmAuditLogEntry.result.result should be(ValNumber(0.1))
   }
 
   it should "contains the result of a BKM function invocation" in {
 
     eval(bkmFunction, "literalExpression", Map("x" -> 2, "y" -> 3))
 
-    auditLog.rootEntry.id should be("literalExpression")
-    auditLog.rootEntry.name should be("BKM with Literal Expression")
-    auditLog.rootEntry.decisionLogic shouldBe a[ParsedLiteralExpression]
-    auditLog.rootEntry.result shouldBe a[SingleEvaluationResult]
+    auditLog.entries should have size (2)
 
-    val result = auditLog.rootEntry.result.asInstanceOf[SingleEvaluationResult]
+    val bkmAuditLogEntry = auditLog.entries.head
+    val rootAuditLogEntry = auditLog.entries.last
+
+    rootAuditLogEntry.id should be("literalExpression")
+    rootAuditLogEntry.name should be("BKM with Literal Expression")
+    rootAuditLogEntry.decisionLogic shouldBe a[ParsedLiteralExpression]
+    rootAuditLogEntry.result shouldBe a[SingleEvaluationResult]
+
+    val result = rootAuditLogEntry.result.asInstanceOf[SingleEvaluationResult]
     result.result should be(ValNumber(5))
 
-    auditLog.requiredEntries.size should be(1)
-    auditLog.requiredEntries(0).name should be("Sum")
-    auditLog
-      .requiredEntries(0)
-      .decisionLogic shouldBe a[ParsedLiteralExpression]
-    auditLog.requiredEntries(0).result shouldBe a[SingleEvaluationResult]
-    auditLog.requiredEntries(0).result.result should be(ValNumber(5))
+    bkmAuditLogEntry.name should be("Sum")
+    bkmAuditLogEntry      .decisionLogic shouldBe a[ParsedLiteralExpression]
+    bkmAuditLogEntry.result shouldBe a[SingleEvaluationResult]
+    bkmAuditLogEntry.result.result should be(ValNumber(5))
   }
 
 }

--- a/src/test/scala/org/camunda/dmn/DmnEngineTest.scala
+++ b/src/test/scala/org/camunda/dmn/DmnEngineTest.scala
@@ -159,7 +159,7 @@ class DmnEngineTest extends AnyFlatSpec with Matchers {
     }
   }
 
-  it should "report a failure if the decision doesn't exist" in {
+  it should "report a failure if no decision exists for the given id" in {
 
     val parseResult = engine.parse(discountDecision)
     parseResult.isRight should be(true)
@@ -173,6 +173,24 @@ class DmnEngineTest extends AnyFlatSpec with Matchers {
       result.isLeft should be(true)
       result.left.map(
         _.failure.message should be("no decision found with id 'not-existing'")
+      )
+    }
+  }
+
+  it should "report a failure if no decision exists for the given name" in {
+
+    val parseResult = engine.parse(discountDecision)
+    parseResult.isRight should be(true)
+
+    parseResult.map { parsedDmn =>
+      val result = engine.evalByName(
+        dmn = parsedDmn,
+        decisionName = "not-existing",
+        variables = Map("customer" -> "Business"))
+
+      result.isLeft should be(true)
+      result.left.map(
+        _.failure.message should be("no decision found with name 'not-existing'")
       )
     }
   }


### PR DESCRIPTION
## Description

If a decision is invoked with a non-existing decision id, the engine returns a failure with an empty audit log. This caused an exception because the audit log couldn't handle an empty list.

Remove the public properties `rootEntry` and `requiredEntries` from the audit log. These properties don't work if the audit log entries are empty.

Note that the property `rootEntry` may contain an audit log entry but no from the root decision. If the evaluation of a required decision fails, the engine doesn't add an entry for the root decision.

## Related issues

closes #135
