### PR TITLE
fix: Detect cyclic dependencies between BKMs

### DIFF
--- a/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
+++ b/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
@@ -129,8 +129,8 @@ class DmnParser(
     }.toMap
 
     decisions.exists(decision =>
-      hasCycle(
-        element = decision.getId,
+      hasDependencyCycle(
+        visit = List(decision.getId),
         visited = Set.empty,
         dependencies = dependencies
       ))
@@ -145,21 +145,24 @@ class DmnParser(
     }.toMap
 
     bkms.exists(bkm =>
-      hasCycle(
-        element = bkm.getId,
+      hasDependencyCycle(
+        visit = List(bkm.getId),
         visited = Set.empty,
         dependencies = dependencies
       ))
   }
 
-  private def hasCycle(element: String,
-                       visited: Set[String],
-                       dependencies: Map[String, Iterable[String]]): Boolean = {
-    if (visited.contains(element)) {
-      true
-    } else {
-      dependencies.getOrElse(element, Nil).exists(dependency =>
-        hasCycle(dependency, visited + element, dependencies)
+  @tailrec
+  private def hasDependencyCycle(visit: List[String],
+                        visited: Set[String],
+                        dependencies: Map[String, Iterable[String]]): Boolean = {
+    visit match {
+      case Nil => false
+      case element :: _ if visited.contains(element) => true
+      case element :: tail => hasDependencyCycle(
+        visit = tail ++ dependencies.getOrElse(element, Nil),
+        visited = visited + element,
+        dependencies = dependencies
       )
     }
   }

--- a/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
+++ b/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
@@ -87,11 +87,12 @@ class DmnParser(
     val ctx = ParsingContext(model)
 
     val drgElements = model.getDefinitions.getDrgElements.asScala
-    val decisions = drgElements.collect { case d: Decision => d }
 
     checkForCyclicDependencies(drgElements) match {
       case Left(failure) => Left(List(failure))
       case _ =>
+        val decisions = drgElements.collect { case d: Decision => d }
+
         decisions.foreach(d =>
           ctx.decisions.getOrElseUpdate(d.getId, parseDecision(d)(ctx)))
 

--- a/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
+++ b/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
@@ -121,31 +121,35 @@ class DmnParser(
   }
 
   private def hasCyclicDependenciesInDecisions(decisions: Iterable[Decision]): Boolean = {
-    val decisionsToRequiredDecisions = decisions
-      .map(
-        d =>
-          d.getId -> d.getInformationRequirements.asScala
-            .flatMap(r => Option(r.getRequiredDecision).map(d => d.getId))
-      )
-      .toMap
+    val dependencies = decisions.map { decision =>
+      val requiredDecisions = decision.getInformationRequirements.asScala
+        .flatMap(requirement => Option(requirement.getRequiredDecision).map(_.getId))
 
-    decisionsToRequiredDecisions
-      .exists(entry =>
-        hasCycle(entry._1, Set.empty, decisionsToRequiredDecisions))
+      decision.getId -> requiredDecisions
+    }.toMap
+
+    decisions.exists(decision =>
+      hasCycle(
+        element = decision.getId,
+        visited = Set.empty,
+        dependencies = dependencies
+      ))
   }
 
   private def hasCyclicDependenciesInBkms(bkms: Iterable[BusinessKnowledgeModel]): Boolean = {
-    val bkmToRequiredBkms = bkms
-      .map(
-        d =>
-          d.getId -> d.getKnowledgeRequirement.asScala
-            .flatMap(r => Option(r.getRequiredKnowledge).map(d => d.getId))
-      )
-      .toMap
+    val dependencies = bkms.map { bkm =>
+      val requiredBkms = bkm.getKnowledgeRequirement.asScala
+        .flatMap(requirement => Option(requirement.getRequiredKnowledge).map(_.getId))
 
-    bkmToRequiredBkms
-      .exists(entry =>
-        hasCycle(entry._1, Set.empty, bkmToRequiredBkms))
+      bkm.getId -> requiredBkms
+    }.toMap
+
+    bkms.exists(bkm =>
+      hasCycle(
+        element = bkm.getId,
+        visited = Set.empty,
+        dependencies = dependencies
+      ))
   }
 
   private def hasCycle(element: String,

--- a/src/test/resources/requirements/cyclic-dependencies-in-bkm.dmn
+++ b/src/test/resources/requirements/cyclic-dependencies-in-bkm.dmn
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://www.omg.org/spec/DMN/20151101/dmn.xsd" xmlns:camunda="http://camunda.org/schema/1.0/dmn" id="definitions_16rwaqm" name="definitions" namespace="http://camunda.org/schema/1.0/dmn">
+  <decision id="decision" name="Decision">
+    <knowledgeRequirement>
+      <requiredKnowledge href="#calculation"/>
+    </knowledgeRequirement>
+    <literalExpression>
+        <text>Calculation(x, y)</text>
+      </literalExpression>
+  </decision>
+  <businessKnowledgeModel id="calculation" name="Calculation">
+    <encapsulatedLogic>
+      <formalParameter name="a" />
+      <formalParameter name="b" />
+      <context>
+        <contextEntry>
+            <variable name="Sum"/>
+            <literalExpression>
+                <text>a + b</text>
+            </literalExpression>
+        </contextEntry>
+        <contextEntry>
+            <variable name="Multiply"/>
+             <literalExpression>
+                <text>Multiply(a * b)</text>
+            </literalExpression>
+        </contextEntry>
+    </context>
+    </encapsulatedLogic>
+    <variable name="Calculation" />
+    <knowledgeRequirement>
+      <requiredKnowledge href="#multiply"/>
+    </knowledgeRequirement>
+  </businessKnowledgeModel>
+  <businessKnowledgeModel id="multiply" name="Multiply">
+    <encapsulatedLogic>
+      <formalParameter name="a" />
+      <formalParameter name="b" />
+      <literalExpression>
+          <text>a * b</text>
+      </literalExpression>
+    </encapsulatedLogic>
+    <variable name="Multiply" />
+    <knowledgeRequirement>
+      <requiredKnowledge href="#calculation"/>
+    </knowledgeRequirement>
+  </businessKnowledgeModel>
+</definitions>

--- a/src/test/scala/org/camunda/dmn/DmnParserTest.scala
+++ b/src/test/scala/org/camunda/dmn/DmnParserTest.scala
@@ -28,4 +28,13 @@ class DmnParserTest extends AnyFlatSpec with Matchers with DecisionTest {
       "Invalid DMN model: Cyclic dependencies between decisions detected.")
   }
 
+  "A DMN file with cyclic dependencies between BKMs" should "return an error" in {
+    val failure =
+      parseDmn("/requirements/cyclic-dependencies-in-bkm.dmn").failure
+
+    failure.message should be(
+      "Invalid DMN model: Cyclic dependencies between BKMs detected.")
+  }
+
+
 }


### PR DESCRIPTION
## Description

The engine fails the parsing of a DMN if it contains a cyclic dependency between BKMs.

## Related issues

closes #149 
