### PR TITLE
deps: Replace log4j-slf4j-impl by log4j-slf4j2-impl

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j-impl</artifactId>
+        <artifactId>log4j-slf4j2-impl</artifactId>
         <version>2.20.0</version>
       </dependency>
 
@@ -125,7 +125,7 @@
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
+      <artifactId>log4j-slf4j2-impl</artifactId>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
## Description

The dependency `log4j-slf4j-impl` is not compatible with `slf4j2`. As a result, the DMN engine doesn't print any logging.

Replace the dependency with the compatible version `log4j-slf4j2-impl`.

## Related issues


