### PR TITLE
Fix incorrect cyclic dependency detection

### DIFF
--- a/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
+++ b/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
@@ -137,7 +137,7 @@ class DmnParser(
 
     decisions.exists(decision =>
       hasDependencyCycle(
-        visit = List(decision.getId),
+        visit = decision.getId,
         visited = Set.empty,
         dependencies = dependencies
       ))
@@ -153,23 +153,24 @@ class DmnParser(
 
     bkms.exists(bkm =>
       hasDependencyCycle(
-        visit = List(bkm.getId),
+        visit = bkm.getId,
         visited = Set.empty,
         dependencies = dependencies
       ))
   }
 
-  @tailrec
-  private def hasDependencyCycle(visit: List[String],
+  private def hasDependencyCycle(visit: String,
                         visited: Set[String],
                         dependencies: Map[String, Iterable[String]]): Boolean = {
-    visit match {
-      case Nil => false
-      case element :: _ if visited.contains(element) => true
-      case element :: tail => hasDependencyCycle(
-        visit = tail ++ dependencies.getOrElse(element, Nil),
-        visited = visited + element,
-        dependencies = dependencies
+    if (visited.contains(visit)) {
+      true
+    } else {
+      dependencies.getOrElse(visit, Nil).exists(dependency =>
+        hasDependencyCycle(
+          visit = dependency,
+          visited = visited + visit,
+          dependencies = dependencies
+        )
       )
     }
   }

--- a/src/test/resources/requirements/non-cyclic-nested-dependencies-in-decisions.dmn
+++ b/src/test/resources/requirements/non-cyclic-nested-dependencies-in-decisions.dmn
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/" xmlns:dmndi="https://www.omg.org/spec/DMN/20191111/DMNDI/" xmlns:dc="http://www.omg.org/spec/DMN/20180521/DC/" xmlns:modeler="http://camunda.org/schema/modeler/1.0" xmlns:di="http://www.omg.org/spec/DMN/20180521/DI/" id="Definitions_0h9zlqh" name="DRD" namespace="http://camunda.org/schema/1.0/dmn" exporter="Camunda Modeler" exporterVersion="5.9.0" modeler:executionPlatform="Camunda Cloud" modeler:executionPlatformVersion="8.2.0">
+  <decision id="C" name="C">
+    <variable id="InformationItem_0s8k0bl" name="out" />
+    <informationRequirement id="InformationRequirement_1rlbqu9">
+      <requiredDecision href="#A" />
+    </informationRequirement>
+    <informationRequirement id="InformationRequirement_05m4j2x">
+      <requiredDecision href="#B" />
+    </informationRequirement>
+    <literalExpression id="LiteralExpression_04arz50">
+      <text>[a, b]</text>
+    </literalExpression>
+  </decision>
+  <decision id="B" name="B">
+    <variable id="InformationItem_16zbv4v" name="b" />
+    <informationRequirement id="InformationRequirement_00uf5b7">
+      <requiredDecision href="#A" />
+    </informationRequirement>
+    <literalExpression id="LiteralExpression_0wt75p4">
+      <text>a + 1</text>
+    </literalExpression>
+  </decision>
+  <decision id="A" name="A">
+    <variable id="InformationItem_0kwllv5" name="a" />
+    <literalExpression id="LiteralExpression_10sjfdq">
+      <text>1</text>
+    </literalExpression>
+  </decision>
+  <dmndi:DMNDI>
+    <dmndi:DMNDiagram>
+      <dmndi:DMNEdge id="DMNEdge_0tire0n" dmnElementRef="InformationRequirement_00uf5b7">
+        <di:waypoint x="250" y="460" />
+        <di:waypoint x="470" y="380" />
+        <di:waypoint x="470" y="360" />
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="DMNEdge_1qeflao" dmnElementRef="InformationRequirement_1rlbqu9">
+        <di:waypoint x="250" y="460" />
+        <di:waypoint x="240" y="180" />
+        <di:waypoint x="240" y="160" />
+      </dmndi:DMNEdge>
+      <dmndi:DMNEdge id="DMNEdge_1j44nm2" dmnElementRef="InformationRequirement_05m4j2x">
+        <di:waypoint x="470" y="280" />
+        <di:waypoint x="300" y="180" />
+        <di:waypoint x="300" y="160" />
+      </dmndi:DMNEdge>
+      <dmndi:DMNShape id="DMNShape_0elqq7s" dmnElementRef="C">
+        <dc:Bounds height="80" width="180" x="180" y="80" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_182794f" dmnElementRef="B">
+        <dc:Bounds height="80" width="180" x="380" y="280" />
+      </dmndi:DMNShape>
+      <dmndi:DMNShape id="DMNShape_0321hm2" dmnElementRef="A">
+        <dc:Bounds height="80" width="180" x="160" y="460" />
+      </dmndi:DMNShape>
+    </dmndi:DMNDiagram>
+  </dmndi:DMNDI>
+</definitions>

--- a/src/test/scala/org/camunda/dmn/DmnParserTest.scala
+++ b/src/test/scala/org/camunda/dmn/DmnParserTest.scala
@@ -28,6 +28,12 @@ class DmnParserTest extends AnyFlatSpec with Matchers with DecisionTest {
       "Invalid DMN model: Cyclic dependencies between decisions detected.")
   }
 
+  "A DMN file with non-cyclic nested dependencies" should "be parsed successfully" in {
+    val parsedResult = parseDmn("/requirements/non-cyclic-nested-dependencies-in-decisions.dmn")
+
+    parsedResult.parserResult.isRight should be(true)
+  }
+
   "A DMN file with cyclic dependencies between BKMs" should "return an error" in {
     val failure =
       parseDmn("/requirements/cyclic-dependencies-in-bkm.dmn").failure


### PR DESCRIPTION
## Description

<!-- Please explain the changes you made here. -->
<img width="469" alt="image" src="https://user-images.githubusercontent.com/5787702/233024621-6feff162-3265-49ff-a0c3-4e0cba220b35.png">
In this model there is no cyclic dependency. The parser incorrectly gives a warning that there is a cyclic dependency.

The cause lays in the cyclic dependency check. This check takes a list of decisions it still needs to visit. It builds this list from the dependencies of previous decisions that have been checked.
The scoping of this check is wrong.  It checks the dependencies in a cyclic way for the entire DRG. With each cycle we append to the visited elements. Upon reaching an end state, we do not clear this list of visited elements.

For the example DRG this means:

1. We check for cyclic dependencies in C
2. We check for cyclic dependencies in A (visited C)
3. A doesn't have any more dependencies, yet we append it to the list of visited elements and continue with the other decisions
4. We check for cyclic dependencies in B (visited C and A)
5. B finds a dependency on A, we've already visited A. As a result we incorrectly assume a cyclic dependency here.

This PR fixes the scoping by not passing a list of decisions to visit, but instead keeping it scoped to a single one. By checking if any dependencies exist with a cycle for this decision we don't run into the issue mentioned above.

## Related issues

<!-- Which issues are closed by this PR or are related -->

closes #213 
