### PR TITLE
71 from poc - dynamic import loading

### DIFF
--- a/api-check-ignore.xml
+++ b/api-check-ignore.xml
@@ -11,7 +11,6 @@
         <!-- num method params -->
         <differenceType>7004</differenceType>
         <method>*$anonfun*</method>
-        <from>*</from>
         <to>*</to>
     </difference>
     <difference>
@@ -19,8 +18,6 @@
         <!-- method param type -->
         <differenceType>7005</differenceType>
         <method>*$anonfun*</method>
-        <!--don't care what the type has changed to-->
-        <from>*</from>
         <to>*</to>
     </difference>
     <difference>
@@ -43,4 +40,39 @@
         <differenceType>7002</differenceType>
         <method>*</method>
     </difference>
+    <!-- changes from 1.8.1 to 1.9 -->
+    <difference>
+        <className>org/camunda/dmn/DmnEngine</className>
+        <differenceType>7004</differenceType>
+        <method>DmnEngine(*</method>
+    </difference>
+    <difference>
+        <className>org/camunda/dmn/parser/DmnParser</className>
+        <differenceType>7004</differenceType>
+        <method>DmnParser(*</method>
+    </difference>
+    <difference>
+        <className>org/camunda/dmn/parser/ParsedDmn</className>
+        <differenceType>7004</differenceType>
+        <method>*</method>
+    </difference>
+    <difference>
+        <className>org/camunda/dmn/parser/ParsedBusinessKnowledgeModel</className>
+        <differenceType>2000</differenceType>
+    </difference>
+    <difference>
+        <className>org/camunda/dmn/parser/ParsedBusinessKnowledgeModel</className>
+        <differenceType>4001</differenceType>
+        <to>**</to>
+    </difference>
+    <difference>
+        <className>org/camunda/dmn/parser/ParsedDecision</className>
+        <differenceType>2000</differenceType>
+    </difference>
+    <difference>
+        <className>org/camunda/dmn/parser/ParsedDecision</className>
+        <differenceType>4001</differenceType>
+        <to>**</to>
+    </difference>
+    <!-- END changes from 1.8.1 to 1.9 -->
 </differences>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.camunda.bpm.extension.dmn.scala</groupId>
   <artifactId>dmn-engine</artifactId>
   <name>DMN Scala Engine</name>
-  <version>1.8.2-SNAPSHOT</version>
+  <version>1.9.0-SNAPSHOT</version>
 
   <parent>
     <groupId>org.camunda</groupId>

--- a/src/main/scala/org/camunda/dmn/evaluation/BusinessKnowledgeEvaluator.scala
+++ b/src/main/scala/org/camunda/dmn/evaluation/BusinessKnowledgeEvaluator.scala
@@ -31,7 +31,7 @@ class BusinessKnowledgeEvaluator(
   def eval(bkm: ParsedBusinessKnowledgeModel,
            context: EvalContext): Either[Failure, Val] = {
 
-    evalRequiredKnowledge(bkm.requiredBkms, context)
+    evalRequiredKnowledge(bkm.requiredBkms.map(_.resolve()), context)
       .flatMap(functions => {
 
         val evalContext =
@@ -47,7 +47,7 @@ class BusinessKnowledgeEvaluator(
       bkm: ParsedBusinessKnowledgeModel,
       context: EvalContext): Either[Failure, (String, ValFunction)] = {
 
-    evalRequiredKnowledge(bkm.requiredBkms, context).map(functions => {
+    evalRequiredKnowledge(bkm.requiredBkms.map(_.resolve()), context).map(functions => {
 
       val evalContext = context.copy(variables = context.variables ++ functions,
                                      currentElement = bkm)

--- a/src/main/scala/org/camunda/dmn/evaluation/DecisionEvaluator.scala
+++ b/src/main/scala/org/camunda/dmn/evaluation/DecisionEvaluator.scala
@@ -51,7 +51,6 @@ class DecisionEvaluator(
             val decisionEvaluationContext = context.copy(
               variables = context.variables
                 ++ decisionResults ++ functions,
-                //                ++ embeddedFunctions ++ importedFunctions,
                 currentElement = decision)
 
             eval(decision.logic, decisionEvaluationContext)
@@ -77,8 +76,8 @@ class DecisionEvaluator(
     requiredBkms: Iterable[ParsedBusinessKnowledgeModelReference],
     context: EvalContext): Either[Failure, List[(String, Val)]] = {
     mapEither(requiredBkms,
-      (bkm: ParsedBusinessKnowledgeModelReference) => evalBkm(bkm.resolve(), context)
-        .map(maybeWrapResult(bkm, _)))
+      (bkmRef: ParsedBusinessKnowledgeModelReference) => evalBkm(bkmRef.resolve(), context)
+        .map(maybeWrapResult(bkmRef, _)))
   }
 
   private def maybeWrapResult(

--- a/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
+++ b/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
@@ -344,31 +344,6 @@ class DmnParser(
     }
   }
 
-  private def createReferenceForImportedBkm(importedModel: ImportedModel, reference: ModelReference)(
-    implicit
-    ctx: ParsingContext): ImportedBusinessKnowledgeModel = {
-    ImportedBusinessKnowledgeModel(dmnRepository, reference.namespace, reference.id, Some(importedModel.name))
-    //    ImportedBusinessKnowledgeModel(() => {
-    //      // todo: extract loading, try to move to evaluation phase
-    //      dmnRepository.getBusinessKnowledgeModel(
-    //        namespace = reference.namespace,
-    //        bkmId = reference.id
-    //      ) match {
-    //        case Right(bkm) => EmbeddedBusinessKnowledgeModel(
-    //          id = reference.id,
-    //          // todo: replace the hack to add the namespace to the name
-    //          name = s"${importedModel.name}.${bkm.name}",
-    //          logic = bkm.logic,
-    //          parameters = bkm.parameters,
-    //          requiredBkms = bkm.requiredBkms
-    //        )
-    //        case Left(failure) =>
-    //          ctx.failures += Failure(failure.message)
-    //          EmbeddedBusinessKnowledgeModel(reference.id, "", EmptyLogic, Iterable.empty, Iterable.empty)
-    //      }
-    //    })
-  }
-
   private def parseBusinessKnowledgeModel(bkm: BusinessKnowledgeModel)(
     implicit
     ctx: ParsingContext): ParsedBusinessKnowledgeModelReference = {

--- a/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
+++ b/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
@@ -67,11 +67,11 @@ object DmnParser {
 }
 
 class DmnParser(
-                 configuration: Configuration,
-                 feelParser: String => Either[String, feel.syntaxtree.ParsedExpression],
-                 feelUnaryTestsParser: String => Either[String,
-                   feel.syntaxtree.ParsedExpression],
-                 dmnRepository: DmnRepository) {
+  configuration: Configuration,
+  feelParser: String => Either[String, feel.syntaxtree.ParsedExpression],
+  feelUnaryTestsParser: String => Either[String,
+    feel.syntaxtree.ParsedExpression],
+  dmnRepository: DmnRepository) {
 
   import DmnParser._
 
@@ -79,6 +79,7 @@ class DmnParser(
 
   case class ModelReference(namespace: String, id: String) {
     def isEmbedded: Boolean = namespace.isEmpty
+
     def isImported: Boolean = !isEmbedded
   }
 
@@ -335,11 +336,11 @@ class DmnParser(
         .find(importedModel => reference.namespace == importedModel.namespace)
         .map(importedModel => ImportedBusinessKnowledgeModel(
           dmnRepository, reference.namespace, reference.id, Some(importedModel.name)))
-          .getOrElse {
-            val failure = Failure(s"No import found for namespace '${reference.namespace}'.")
-            ctx.failures += failure
-            ParsedBusinessKnowledgeModelFailure(reference.id, reference.namespace, ExpressionFailure(failure.message))
-          }
+        .getOrElse {
+          val failure = Failure(s"No import found for namespace '${reference.namespace}'.")
+          ctx.failures += failure
+          ParsedBusinessKnowledgeModelFailure(reference.id, reference.namespace, ExpressionFailure(failure.message))
+        }
     }
   }
 
@@ -558,18 +559,16 @@ class DmnParser(
     ctx: ParsingContext): ParsedDecisionLogic = {
 
     val bindings = invocation.getBindings.asScala
-      .map(b =>
+      .flatMap(b =>
         b.getExpression match {
           case lt: LiteralExpression =>
             Some(b.getParameter.getName -> parseFeelExpression(lt))
           case other => {
             ctx.failures += Failure(
               s"expected binding with literal expression but found '$other'")
-
             None
           }
         })
-      .flatten
 
     invocation.getExpression match {
       case lt: LiteralExpression => {
@@ -577,8 +576,8 @@ class DmnParser(
 
         ctx.bkms
           .get(expression)
-          .map(bkm => {
-            ParsedInvocation(bindings, bkm.resolve())
+          .map(bkmRef => {
+            ParsedInvocation(bindings, bkmRef.resolve())
           })
           .getOrElse {
             ctx.failures += Failure(s"no BKM found with name '$expression'")
@@ -633,8 +632,7 @@ class DmnParser(
       .map(_.getTextContent)
       .toRight(Failure(s"The expression '${lt.getId}' must not be empty."))
 
-  private def validateExpressionLanguage(
-    lt: LiteralExpression): Either[Failure, Unit] = {
+  private def validateExpressionLanguage(lt: LiteralExpression): Either[Failure, Unit] = {
     val language =
       Option(lt.getExpressionLanguage).map(_.toLowerCase).getOrElse("feel")
     if (feelNameSpaces.contains(language)) {

--- a/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
+++ b/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
@@ -15,19 +15,37 @@
  */
 package org.camunda.dmn.parser
 
-import java.io.InputStream
-import org.camunda.dmn.logger
 import org.camunda.bpm.model.dmn._
 import org.camunda.bpm.model.dmn.impl.DmnModelConstants
-import org.camunda.bpm.model.dmn.impl.instance.DrgElementImpl
-import org.camunda.bpm.model.dmn.instance.{BusinessKnowledgeModel, Column, Context, Decision, DecisionTable, Definitions, DmnElementReference, DrgElement, Expression, FunctionDefinition, InformationItem, InformationRequirement, Invocation, ItemDefinition, KnowledgeRequirement, LiteralExpression, Relation, RequiredDecisionReference, RequiredKnowledgeReference, UnaryTests, List => DmnList}
+import org.camunda.bpm.model.dmn.instance.BusinessKnowledgeModel
+import org.camunda.bpm.model.dmn.instance.Column
+import org.camunda.bpm.model.dmn.instance.Context
+import org.camunda.bpm.model.dmn.instance.Decision
+import org.camunda.bpm.model.dmn.instance.DecisionTable
+import org.camunda.bpm.model.dmn.instance.Definitions
+import org.camunda.bpm.model.dmn.instance.DrgElement
+import org.camunda.bpm.model.dmn.instance.Expression
+import org.camunda.bpm.model.dmn.instance.FunctionDefinition
+import org.camunda.bpm.model.dmn.instance.InformationItem
+import org.camunda.bpm.model.dmn.instance.InformationRequirement
+import org.camunda.bpm.model.dmn.instance.Invocation
+import org.camunda.bpm.model.dmn.instance.ItemDefinition
+import org.camunda.bpm.model.dmn.instance.KnowledgeRequirement
+import org.camunda.bpm.model.dmn.instance.LiteralExpression
+import org.camunda.bpm.model.dmn.instance.Relation
+import org.camunda.bpm.model.dmn.instance.RequiredDecisionReference
+import org.camunda.bpm.model.dmn.instance.RequiredKnowledgeReference
+import org.camunda.bpm.model.dmn.instance.UnaryTests
+import org.camunda.bpm.model.dmn.instance.{List => DmnList}
 import org.camunda.bpm.model.xml.instance.ModelElementInstance
-import org.camunda.dmn.DmnEngine.{Configuration, Failure}
+import org.camunda.dmn.DmnEngine.Configuration
+import org.camunda.dmn.DmnEngine.Failure
+import org.camunda.dmn.logger
 import org.camunda.feel
 
-import scala.annotation.tailrec
-import scala.collection.JavaConverters._
+import java.io.InputStream
 import scala.collection.mutable
+import scala.jdk.CollectionConverters._
 import scala.util.Try
 
 object DmnParser {
@@ -71,8 +89,8 @@ class DmnParser(
     val parsedFeelExpressions = mutable.Map[String, ParsedExpression]()
     val parsedFeelUnaryTest = mutable.Map[String, ParsedExpression]()
 
-    val decisions = mutable.Map[String, ParsedDecision]()
-    val bkms = mutable.Map[String, ParsedBusinessKnowledgeModel]()
+    val decisions = mutable.Map[String, ParsedDecisionReference]()
+    val bkms = mutable.Map[String, ParsedBusinessKnowledgeModelReference]()
 
     val importedModels = mutable.ListBuffer[ImportedModel]()
 
@@ -102,7 +120,7 @@ class DmnParser(
   }
 
   private def parseModel(
-                          model: DmnModelInstance): Either[Iterable[Failure], ParsedDmn] = {
+    model: DmnModelInstance): Either[Iterable[Failure], ParsedDmn] = {
 
     val ctx = ParsingContext(model)
 
@@ -126,8 +144,8 @@ class DmnParser(
 
         val parsedDmn = ParsedDmn(
           model = model,
-          decisions = ctx.decisions.values,
-          bkms = ctx.bkms.values,
+          decisions = ctx.decisions.values.filter(_.isEmbedded).map(_.resolve()),
+          bkms = ctx.bkms.values.filter(_.isEmbedded).map(_.resolve()),
           namespace = definitions.getNamespace)
 
         if (ctx.failures.isEmpty) {
@@ -227,7 +245,7 @@ class DmnParser(
 
   private def parseDecision(decision: Decision)(
     implicit
-    ctx: ParsingContext): ParsedDecision = {
+    ctx: ParsingContext): ParsedDecisionReference = {
 
     val requiredDecisions = decision.getInformationRequirements.asScala
       .flatMap(requirement =>
@@ -287,44 +305,20 @@ class DmnParser(
     )
   }
 
-  private def parseRequiredDecision(informationRequirement: InformationRequirement, reference: ModelReference)(implicit ctx: ParsingContext): ParsedDecision = {
+  private def parseRequiredDecision(informationRequirement: InformationRequirement, reference: ModelReference)(implicit ctx: ParsingContext): ParsedDecisionReference = {
     if (reference.isEmbedded) {
       val requiredDecision = informationRequirement.getRequiredDecision
       ctx.decisions.getOrElseUpdate(requiredDecision.getId, parseDecision(decision = requiredDecision))
     } else {
       ctx.importedModels
         .find(importedModel => reference.namespace == importedModel.namespace)
-        .map(importedModel => createReferenceForImportedDecision(importedModel, reference))
+        .map(importedModel => ImportedDecision(dmnRepository, reference.namespace, reference.id, Some(importedModel.name)))
         .getOrElse {
-          ctx.failures += Failure(s"No import found for namespace '${reference.namespace}'.")
-          ImportedDecision(() =>
-            throw new RuntimeException(s"Failed to invoke decision. No import found for namespace '${reference.namespace}'.")
-          )
+          val failure = Failure(s"No import found for namespace '${reference.namespace}'.")
+          ctx.failures += failure
+          ParsedDecisionFailure(reference.id, reference.namespace, ExpressionFailure(failure.message))
         }
     }
-  }
-
-  private def createReferenceForImportedDecision(importedModel: ImportedModel, reference: ModelReference): ImportedDecision = {
-    ImportedDecision(() => {
-      // todo: extract loading, try to move to evaluation phase
-      dmnRepository.getDecision(
-        namespace = reference.namespace,
-        decisionId = reference.id
-      ) match {
-        case Right(decision) => EmbeddedDecision(
-          id = reference.id,
-          // todo: replace the hack to add the namespace to the name
-          name = s"${importedModel.name}.${decision.name}",
-          resultName = s"${importedModel.name}.${decision.resultName}",
-          logic = decision.logic,
-          resultType = decision.resultType,
-          requiredDecisions = decision.requiredDecisions,
-          requiredBkms = decision.requiredBkms
-        )
-        // todo: don't throw an exception if a decision was not found, but return a failure
-        case Left(failure) => throw new RuntimeException(failure.message)
-      }
-    })
   }
 
   private def getBkmReference(knowledgeRequirement: KnowledgeRequirement): Option[ModelReference] = {
@@ -332,47 +326,51 @@ class DmnParser(
       .map(createModelReference)
   }
 
-  private def parseRequiredBkm(knowledgeRequirement: KnowledgeRequirement, reference: ModelReference)(implicit ctx: ParsingContext): ParsedBusinessKnowledgeModel = {
+  private def parseRequiredBkm(knowledgeRequirement: KnowledgeRequirement, reference: ModelReference)(implicit ctx: ParsingContext): ParsedBusinessKnowledgeModelReference = {
     if (reference.isEmbedded) {
       val requiredKnowledge = knowledgeRequirement.getRequiredKnowledge
       ctx.bkms.getOrElseUpdate(requiredKnowledge.getName, parseBusinessKnowledgeModel(requiredKnowledge))
     } else {
       ctx.importedModels
         .find(importedModel => reference.namespace == importedModel.namespace)
-        .map(importedModel => createReferenceForImportedBkm(importedModel, reference))
-        .getOrElse {
-          ctx.failures += Failure(s"No import found for namespace '${reference.namespace}'.")
-          ImportedBusinessKnowledgeModel(() =>
-            throw new RuntimeException(s"Failed to invoke BKM. No import found for namespace '${reference.namespace}'.")
-          )
-        }
+        .map(importedModel => ImportedBusinessKnowledgeModel(
+          dmnRepository, reference.namespace, reference.id, Some(importedModel.name)))
+          .getOrElse {
+            val failure = Failure(s"No import found for namespace '${reference.namespace}'.")
+            ctx.failures += failure
+            ParsedBusinessKnowledgeModelFailure(reference.id, reference.namespace, ExpressionFailure(failure.message))
+          }
     }
   }
 
-  private def createReferenceForImportedBkm(importedModel: ImportedModel, reference: ModelReference): ImportedBusinessKnowledgeModel = {
-    ImportedBusinessKnowledgeModel(() => {
-      // todo: extract loading, try to move to evaluation phase
-      dmnRepository.getBusinessKnowledgeModel(
-        namespace = reference.namespace,
-        bkmId = reference.id
-      ) match {
-        case Right(bkm) => EmbeddedBusinessKnowledgeModel(
-          id = reference.id,
-          // todo: replace the hack to add the namespace to the name
-          name = s"${importedModel.name}.${bkm.name}",
-          logic = bkm.logic,
-          parameters = bkm.parameters,
-          requiredBkms = bkm.requiredBkms
-        )
-        // todo: don't throw an exception if a BKM was not found, but return a failure
-        case Left(failure) => throw new RuntimeException(failure.message)
-      }
-    })
+  private def createReferenceForImportedBkm(importedModel: ImportedModel, reference: ModelReference)(
+    implicit
+    ctx: ParsingContext): ImportedBusinessKnowledgeModel = {
+    ImportedBusinessKnowledgeModel(dmnRepository, reference.namespace, reference.id, Some(importedModel.name))
+    //    ImportedBusinessKnowledgeModel(() => {
+    //      // todo: extract loading, try to move to evaluation phase
+    //      dmnRepository.getBusinessKnowledgeModel(
+    //        namespace = reference.namespace,
+    //        bkmId = reference.id
+    //      ) match {
+    //        case Right(bkm) => EmbeddedBusinessKnowledgeModel(
+    //          id = reference.id,
+    //          // todo: replace the hack to add the namespace to the name
+    //          name = s"${importedModel.name}.${bkm.name}",
+    //          logic = bkm.logic,
+    //          parameters = bkm.parameters,
+    //          requiredBkms = bkm.requiredBkms
+    //        )
+    //        case Left(failure) =>
+    //          ctx.failures += Failure(failure.message)
+    //          EmbeddedBusinessKnowledgeModel(reference.id, "", EmptyLogic, Iterable.empty, Iterable.empty)
+    //      }
+    //    })
   }
 
   private def parseBusinessKnowledgeModel(bkm: BusinessKnowledgeModel)(
     implicit
-    ctx: ParsingContext): ParsedBusinessKnowledgeModel = {
+    ctx: ParsingContext): ParsedBusinessKnowledgeModelReference = {
 
     // TODO be aware of loops
     val knowledgeRequirements = bkm.getKnowledgeRequirement.asScala
@@ -580,7 +578,7 @@ class DmnParser(
         ctx.bkms
           .get(expression)
           .map(bkm => {
-            ParsedInvocation(bindings, bkm)
+            ParsedInvocation(bindings, bkm.resolve())
           })
           .getOrElse {
             ctx.failures += Failure(s"no BKM found with name '$expression'")
@@ -636,7 +634,7 @@ class DmnParser(
       .toRight(Failure(s"The expression '${lt.getId}' must not be empty."))
 
   private def validateExpressionLanguage(
-                                          lt: LiteralExpression): Either[Failure, Unit] = {
+    lt: LiteralExpression): Either[Failure, Unit] = {
     val language =
       Option(lt.getExpressionLanguage).map(_.toLowerCase).getOrElse("feel")
     if (feelNameSpaces.contains(language)) {
@@ -683,11 +681,11 @@ class DmnParser(
       ctx.parsedFeelUnaryTest.getOrElseUpdate(
         expression, {
 
-          if (expression.isEmpty()) {
+          if (expression.isEmpty) {
             EmptyExpression
           } else {
 
-            var escapedExpression =
+            val escapedExpression =
               escapeNamesInExpression(expression, ctx.namesToEscape)
 
             feelUnaryTestsParser(escapedExpression) match {
@@ -705,8 +703,8 @@ class DmnParser(
   }
 
   private def escapeNamesInExpression(
-                                       expression: String,
-                                       namesWithSpaces: Iterable[String]): String = {
+    expression: String,
+    namesWithSpaces: Iterable[String]): String = {
 
     (expression /: namesWithSpaces)(
       (e, name) =>

--- a/src/main/scala/org/camunda/dmn/parser/DmnRepository.scala
+++ b/src/main/scala/org/camunda/dmn/parser/DmnRepository.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2022 Camunda Services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.camunda.dmn.parser
 
 import org.camunda.dmn.DmnEngine.Failure

--- a/src/main/scala/org/camunda/dmn/parser/InMemoryDmnRepository.scala
+++ b/src/main/scala/org/camunda/dmn/parser/InMemoryDmnRepository.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2022 Camunda Services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.camunda.dmn.parser
 
 import org.camunda.dmn.DmnEngine.Failure

--- a/src/main/scala/org/camunda/dmn/parser/ParsedDmn.scala
+++ b/src/main/scala/org/camunda/dmn/parser/ParsedDmn.scala
@@ -51,7 +51,7 @@ sealed trait ParsedDecisionLogicContainer {
   val logic: ParsedDecisionLogic
 }
 
-sealed trait ParsedDecision extends ParsedDecisionLogicContainer{
+trait ParsedDecision extends ParsedDecisionLogicContainer {
   val resultName: String
   val resultType: Option[String]
   val requiredDecisions: Iterable[ParsedDecisionReference]
@@ -76,8 +76,7 @@ case class EmbeddedDecision(
   resultType: Option[String],
   requiredDecisions: Iterable[ParsedDecisionReference],
   requiredBkms: Iterable[ParsedBusinessKnowledgeModelReference]
-)
-  extends ParsedDecision with ParsedDecisionReference {
+) extends ParsedDecision with ParsedDecisionReference {
   override def resolve(): ParsedDecision = this
 
   override def isEmbedded: Boolean = true
@@ -112,20 +111,22 @@ trait ParsedBusinessKnowledgeModelReference extends ParsedDecisionLogicContainer
 
 
 case class EmbeddedBusinessKnowledgeModel(
-                                         id: String,
-                                         name: String,
-                                         logic: ParsedDecisionLogic,
-                                         parameters: Iterable[(String, String)],
-                                         requiredBkms: Iterable[ParsedBusinessKnowledgeModelReference])
-  extends ParsedBusinessKnowledgeModel with ParsedBusinessKnowledgeModelReference {
+  id: String,
+  name: String,
+  logic: ParsedDecisionLogic,
+  parameters: Iterable[(String, String)],
+  requiredBkms: Iterable[ParsedBusinessKnowledgeModelReference]) extends
+ParsedBusinessKnowledgeModel with ParsedBusinessKnowledgeModelReference {
+
   override def resolve(): ParsedBusinessKnowledgeModel = this
 
   override def isEmbedded: Boolean = true
 }
 
 case class ImportedBusinessKnowledgeModel(
-  repository: DmnRepository, namespace: String, id: String, override val importedModelName: Option[String])
-  extends ParsedBusinessKnowledgeModelReference {
+  repository: DmnRepository,
+  namespace: String, id: String,
+  override val importedModelName: Option[String]) extends ParsedBusinessKnowledgeModelReference {
   override def resolve(): ParsedBusinessKnowledgeModel = repository.getBusinessKnowledgeModel(namespace, id) match {
     case Right(found) => found
     case Left(failure) =>

--- a/src/main/scala/org/camunda/dmn/parser/StatelessDmnRepository.scala
+++ b/src/main/scala/org/camunda/dmn/parser/StatelessDmnRepository.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2022 Camunda Services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.camunda.dmn.parser
 
 import org.camunda.dmn.DmnEngine.Failure

--- a/src/test/scala/org/camunda/dmn/DmnImportTest.scala
+++ b/src/test/scala/org/camunda/dmn/DmnImportTest.scala
@@ -1,3 +1,18 @@
+/*
+ * Copyright © 2022 Camunda Services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.camunda.dmn
 
 import org.camunda.dmn.parser.InMemoryDmnRepository
@@ -11,14 +26,14 @@ class DmnImportTest extends AnyFlatSpec with Matchers with DecisionTest{
     dmnRepository = new InMemoryDmnRepository()
   )
 
+  private val decisionWithBkmImport = parse("/tck/0086-import/0086-import.dmn")
+  private val decisionWithDecisionImport = parse("/tck/0089-nested-inputdata-imports/0089-nested-inputdata-imports.dmn")
+
   // parse required DMNs
   parse("/tck/0086-import/Imported_Model.dmn")
   parse("/tck/0089-nested-inputdata-imports/Say_hello_1ID1D.dmn")
   parse("/tck/0089-nested-inputdata-imports/Model_B.dmn")
   parse("/tck/0089-nested-inputdata-imports/Model_B2.dmn")
-
-  private val decisionWithBkmImport = parse("/tck/0086-import/0086-import.dmn")
-  private val decisionWithDecisionImport = parse("/tck/0089-nested-inputdata-imports/0089-nested-inputdata-imports.dmn")
 
   "A decision with an imported BKM" should "invoke the BKM from the imported DMN" in {
     eval(decisionWithBkmImport,


### PR DESCRIPTION
## Description

This addresses the following todos referenced in https://github.com/camunda/dmn-scala/pull/222:

- [x] Move the loading of imported decisions/BKMs from the parser to the evaluation logic. The import is part of the evaluation.
- [x]  Handle decisions/BKMs with namespaces natively (i.e. qualified names). Don't modify the name.
- [ ]  Evaluate imported decisions/BKMs differently by wrapping them into a FEEL context. The evaluation interprets the qualified name as a path expression.
- [x]  Handle the case if an imported decision/BKM is not present. Don't throw exceptions.
- [ ]  Document the new public API.
- [ ]  Write more test cases to cover edge cases.
- [ ]  Fix the InvocationTest.scala. Out of scope for this PR because the test was not really correct before.

## Related issues

related to https://github.com/camunda/dmn-scala/issues/71

closes #
