### PR TITLE
feat: Support namespaces of DMN 1.4 and 1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
   <properties>
     <feel.version>1.17.0</feel.version>
-    <camunda-model-api.version>7.19.0</camunda-model-api.version>
+    <camunda-model-api.version>7.20.0-alpha5</camunda-model-api.version>
     <version.java>11</version.java>
     <scala.version>2.13.12</scala.version>
     <scala.binary.version>2.13.6</scala.binary.version>

--- a/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
+++ b/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
@@ -34,7 +34,9 @@ object DmnParser {
     "feel",
     DmnModelConstants.FEEL_NS,
     DmnModelConstants.FEEL12_NS,
-    DmnModelConstants.FEEL13_NS
+    DmnModelConstants.FEEL13_NS,
+    DmnModelConstants.FEEL14_NS,
+    DmnModelConstants.DMN15_NS
   ).map(_.toLowerCase())
 }
 

--- a/src/test/resources/dmn1.4/greeting.dmn
+++ b/src/test/resources/dmn1.4/greeting.dmn
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="_0001-input-data-string" name="0001-input-data-string"
+	namespace="https://github.com/agilepro/dmn-tck"
+	xmlns="https://www.omg.org/spec/DMN/20211108/MODEL/"
+	xmlns:feel="https://www.omg.org/spec/DMN/20211108/FEEL/">
+	<decision name="GreetingMessage" id="greeting">
+		<variable name="GreetingMessage" typeRef="feel:string"/>
+		<literalExpression expressionLanguage="https://www.omg.org/spec/DMN/20211108/FEEL/">
+			<text>"Hello " + name</text>
+		</literalExpression>
+	</decision>
+</definitions>

--- a/src/test/resources/dmn1.5/greeting.dmn
+++ b/src/test/resources/dmn1.5/greeting.dmn
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions id="_0001-input-data-string" name="0001-input-data-string"
+	namespace="https://github.com/agilepro/dmn-tck"
+	xmlns="https://www.omg.org/spec/DMN/20230324/MODEL/"
+	xmlns:feel="https://www.omg.org/spec/DMN/20230324/FEEL/">
+	<decision name="GreetingMessage" id="greeting">
+		<variable name="GreetingMessage" typeRef="feel:string"/>
+		<literalExpression expressionLanguage="https://www.omg.org/spec/DMN/20230324/FEEL/">
+			<text>"Hello " + name</text>
+		</literalExpression>
+	</decision>
+</definitions>

--- a/src/test/scala/org/camunda/dmn/DmnVersionCompatibilityTest.scala
+++ b/src/test/scala/org/camunda/dmn/DmnVersionCompatibilityTest.scala
@@ -28,7 +28,11 @@ class DmnVersionCompatibilityTest
 
   private def dmn1_2_decision = parse("/dmn1.2/greeting.dmn")
 
-  private def dmn1_3_decision = parse("/dmn1.2/greeting.dmn")
+  private def dmn1_3_decision = parse("/dmn1.3/greeting.dmn")
+
+  private def dmn1_4_decision = parse("/dmn1.4/greeting.dmn")
+
+  private def dmn1_5_decision = parse("/dmn1.5/greeting.dmn")
 
   "The DMN engine" should "evaluate a DMN 1.1 decision" in {
     eval(dmn1_1_decision, "greeting", Map("name" -> "DMN")) should be(
@@ -42,6 +46,16 @@ class DmnVersionCompatibilityTest
 
   it should "evaluate a DMN 1.3 decision" in {
     eval(dmn1_3_decision, "greeting", Map("name" -> "DMN")) should be(
+      "Hello DMN")
+  }
+
+  it should "evaluate a DMN 1.4 decision" in {
+    eval(dmn1_4_decision, "greeting", Map("name" -> "DMN")) should be(
+      "Hello DMN")
+  }
+
+  it should "evaluate a DMN 1.5 decision" in {
+    eval(dmn1_4_decision, "greeting", Map("name" -> "DMN")) should be(
       "Hello DMN")
   }
 


### PR DESCRIPTION
## Description

* Support the new namespaces of DMN 1.4 and 1.5
* Dump the Camunda model-api to `7.20.0-alpha5`. This is the latest version that contains the support for the new namespaces.

## Related issues

closes #221
