### PR TITLE
chore(maven-central-secrets): Update maven central secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -35,8 +35,8 @@ jobs:
         release-profile: community-action-maven-release
         nexus-usr: ${{ secrets.NEXUS_USR }}
         nexus-psw: ${{ secrets.NEXUS_PSW }}
-        maven-usr: ${{ secrets.MAVEN_CENTRAL_DEPLOYMENT_USR_C7 }}
-        maven-psw: ${{ secrets.MAVEN_CENTRAL_DEPLOYMENT_PSW_C7 }}
+        maven-usr: ${{ secrets.COMMUNITY_HUB_MAVEN_CENTRAL_OSS_USR }}
+        maven-psw: ${{ secrets.COMMUNITY_HUB_MAVEN_CENTRAL_OSS_PSW }}
         maven-gpg-passphrase: ${{ secrets.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
         github-token: ${{ secrets.GITHUB_TOKEN }}
       id: release


### PR DESCRIPTION
## Description

The secrets used for this workflow belongs to the `camunda-hub` user and the secret has now been migrated. See [this](https://github.com/camunda/team-infrastructure/issues/640#issuecomment-2195298760) comment on the related infra ticket 

## Related issues

https://github.com/camunda/team-infrastructure/issues/640

