### PR TITLE
fix(deploy): base64-decode Maven Central GPG signing key before import

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -53,7 +53,7 @@ jobs:
       run: |
         echo -n "${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}" \
           | base64 --decode \
-          | gpg -q --allow-secret-key-import --import --no-tty --batch --yes
+          | gpg -q --import --no-tty --batch --yes
     - name: Deploy SNAPSHOT / Release
       uses: camunda-community-hub/community-action-maven-release@v2
       with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,13 +40,20 @@ jobs:
           secret/data/github.com/organizations/camunda-community-hub COMMUNITY_HUB_MAVEN_CENTRAL_CP_PSW
     - name: Set up Java environment
       uses: actions/setup-java@v5
-      env:
-        MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE }}
       with:
         distribution: 'temurin'
         java-version: 11
-        gpg-private-key: ${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}
-        gpg-passphrase: MAVEN_CENTRAL_GPG_SIGNING_KEY_PASSPHRASE
+    - name: Install Maven Central GPG signing key
+      # The signing key is stored base64-encoded in Vault (see
+      # terraform/github/prod/camunda-community-hub-vault-secrets.tf:
+      # base64_encoded_secrets), so it must be decoded before import. Importing
+      # the raw Vault value directly via setup-java's gpg-private-key fails with
+      # "gpg: exit code 2". Matches the pattern used in camunda/feel-scala.
+      # https://github.com/actions/setup-java/issues/100#issuecomment-742679976
+      run: |
+        echo -n "${{ steps.secrets.outputs.MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC }}" \
+          | base64 --decode \
+          | gpg -q --allow-secret-key-import --import --no-tty --batch --yes
     - name: Deploy SNAPSHOT / Release
       uses: camunda-community-hub/community-action-maven-release@v2
       with:


### PR DESCRIPTION
## What

Decode the `MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC` Vault secret with `base64 --decode` and import it in a dedicated GPG step, instead of passing the raw Vault value to `actions/setup-java`'s `gpg-private-key` input.

## Why

The deploy workflow failed in **Set up Java environment** when releasing a patch version:

```
Importing private gpg key
##[error]The process '/usr/bin/gpg' failed with exit code 2
```

Root cause: the community-hub `MAVEN_CENTRAL_GPG_SIGNING_KEY_SEC` secret is stored **base64-encoded** in Vault — declared in `infra-core` at `terraform/github/prod/camunda-community-hub-vault-secrets.tf` (`base64_encoded_secrets`). `setup-java` fed the raw base64 blob to `gpg --import`, which can't parse it (exit 2).

Before the Vault migration ([#346](https://github.com/camunda/dmn-scala/pull/346)) the key came from a GitHub org secret that stored the raw armored key, so no decode was needed. The migration kept the direct hand-off to `setup-java` but the Vault value requires decoding first.

## How

- Add an **Install Maven Central GPG signing key** step that runs `base64 --decode | gpg --import` — the same pattern used in [`camunda/feel-scala`](https://github.com/camunda/feel-scala/blob/main/.github/workflows/release.yml).
- Remove the `gpg-private-key` / `gpg-passphrase` inputs (and the now-unused `env` block) from the `setup-java` step. The signing passphrase is already passed to the release action via `maven-gpg-passphrase`, which only needs the key present in the runner's GPG keyring.

Verified locally against the real Vault value: `base64 --decode | gpg --import` succeeds (exit 0) and imports the `Camunda Services GmbH <infra@camunda.com>` signing key.

## References

- ask-infra thread: https://camunda.slack.com/archives/C5AHF1D8T/p1781596765743069
- Failing run: https://github.com/camunda/dmn-scala/actions/runs/27614006796/job/81645263194
- Pattern reference: camunda/feel-scala `.github/workflows/release.yml`