### PR TITLE
fix: backport StackOverflowError fix on long decision chains to 1.10.x (#335)

### DIFF
--- a/src/main/scala/org/camunda/dmn/FunctionalHelper.scala
+++ b/src/main/scala/org/camunda/dmn/FunctionalHelper.scala
@@ -49,10 +49,14 @@ object FunctionalHelper {
   def mapEitherTailRec[T, R](
       it: Iterable[T],
       f: T => TailRec[Either[Failure, R]]): TailRec[Either[Failure, List[R]]] = {
+    // Accumulate by prepending (O(1) per element) and reverse once at the
+    // end, rather than appending with `:+` (O(n) per element, O(n^2) total)
+    // — this helper is meant to support large traversals, so it should stay
+    // linear in `it`.
     foldEitherTailRec[T, List[R]](List(), it, {
       case (xs, x) =>
-        tailcall(f(x)).map(_.map(xs :+ _))
-    })
+        tailcall(f(x)).map(_.map(_ :: xs))
+    }).map(_.map(_.reverse))
   }
 
   def foldEitherTailRec[T, R](

--- a/src/main/scala/org/camunda/dmn/FunctionalHelper.scala
+++ b/src/main/scala/org/camunda/dmn/FunctionalHelper.scala
@@ -17,6 +17,8 @@ package org.camunda.dmn
 
 import org.camunda.dmn.DmnEngine.Failure
 
+import scala.util.control.TailCalls._
+
 object FunctionalHelper {
 
   def mapEither[T, R](it: Iterable[T],
@@ -37,6 +39,42 @@ object FunctionalHelper {
       xs.flatMap { xs =>
         f(xs, x)
     })
+  }
+
+  // TailRec-safe variants used where `f` may itself recurse arbitrarily deep
+  // (e.g. evaluating a chain of dependent decisions). These preserve the same
+  // left-to-right, short-circuit-on-first-failure semantics as mapEither/
+  // foldEither above, but never grow the JVM call stack.
+
+  def mapEitherTailRec[T, R](
+      it: Iterable[T],
+      f: T => TailRec[Either[Failure, R]]): TailRec[Either[Failure, List[R]]] = {
+    foldEitherTailRec[T, List[R]](List(), it, {
+      case (xs, x) =>
+        tailcall(f(x)).map(_.map(xs :+ _))
+    })
+  }
+
+  def foldEitherTailRec[T, R](
+      start: R,
+      it: Iterable[T],
+      f: (R, T) => TailRec[Either[Failure, R]]): TailRec[Either[Failure, R]] = {
+
+    val iterator = it.iterator
+
+    def loop(acc: Either[Failure, R]): TailRec[Either[Failure, R]] = {
+      acc match {
+        case Left(_) => done(acc)
+        case Right(value) =>
+          if (!iterator.hasNext) {
+            done(acc)
+          } else {
+            tailcall(f(value, iterator.next())).flatMap(loop)
+          }
+      }
+    }
+
+    loop(Right(start))
   }
 
 }

--- a/src/main/scala/org/camunda/dmn/evaluation/DecisionEvaluator.scala
+++ b/src/main/scala/org/camunda/dmn/evaluation/DecisionEvaluator.scala
@@ -24,6 +24,8 @@ import org.camunda.dmn.parser.{
   ParsedBusinessKnowledgeModel
 }
 
+import scala.util.control.TailCalls._
+
 class DecisionEvaluator(
     eval: (ParsedDecisionLogic, EvalContext) => Either[Failure, Val],
     evalBkm: (ParsedBusinessKnowledgeModel,
@@ -32,16 +34,20 @@ class DecisionEvaluator(
   def eval(decision: ParsedDecision,
            context: EvalContext): Either[Failure, Val] = {
 
-    evalDecision(decision, context)
+    evalDecision(decision, context).result
       .map { case (name, result) => result }
   }
 
+  // Trampolined via TailCalls: evalDecision <-> evalRequiredDecisions is
+  // mutually recursive with depth equal to the length of the decision
+  // requirements chain, which can be in the thousands. Ordinary recursion
+  // here overflows the JVM stack (camunda/dmn-scala#335).
   private def evalDecision(
       decision: ParsedDecision,
-      context: EvalContext): Either[Failure, (String, Val)] = {
+      context: EvalContext): TailRec[Either[Failure, (String, Val)]] = {
 
-    evalRequiredDecisions(decision.requiredDecisions, context)
-      .flatMap(decisionResults => {
+    tailcall(evalRequiredDecisions(decision.requiredDecisions, context))
+      .map(_.flatMap(decisionResults => {
         evalRequiredKnowledge(decision.requiredBkms, context)
           .flatMap(functions => {
 
@@ -57,14 +63,14 @@ class DecisionEvaluator(
                     .getOrElse(Right(result)))
               .map(decision.resultName -> _)
           })
-      })
+      }))
   }
 
   private def evalRequiredDecisions(
       requiredDecisions: Iterable[ParsedDecision],
-      context: EvalContext): Either[Failure, List[(String, Val)]] = {
-    mapEither(requiredDecisions,
-              (d: ParsedDecision) => evalDecision(d, context))
+      context: EvalContext): TailRec[Either[Failure, List[(String, Val)]]] = {
+    mapEitherTailRec(requiredDecisions,
+                     (d: ParsedDecision) => evalDecision(d, context))
   }
 
   private def evalRequiredKnowledge(

--- a/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
+++ b/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
@@ -23,7 +23,6 @@ import org.camunda.bpm.model.dmn.instance.{BusinessKnowledgeModel, Column, Conte
 import org.camunda.dmn.DmnEngine.{Configuration, Failure}
 import org.camunda.feel
 
-import scala.annotation.tailrec
 import scala.util.control.TailCalls._
 import scala.collection.JavaConverters._
 import scala.collection.mutable

--- a/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
+++ b/src/main/scala/org/camunda/dmn/parser/DmnParser.scala
@@ -24,6 +24,7 @@ import org.camunda.dmn.DmnEngine.{Configuration, Failure}
 import org.camunda.feel
 
 import scala.annotation.tailrec
+import scala.util.control.TailCalls._
 import scala.collection.JavaConverters._
 import scala.collection.mutable
 import scala.util.Try
@@ -164,17 +165,46 @@ class DmnParser(
   private def hasDependencyCycle(visit: String,
                         visited: Set[String],
                         dependencies: Map[String, Iterable[String]]): Boolean = {
+    hasDependencyCycleTailRec(visit, visited, dependencies).result
+  }
+
+  // Trampolined via TailCalls: this DFS walk recurses one frame per edge
+  // followed, which overflows the JVM stack for long decision/BKM chains
+  // even when they are acyclic (camunda/dmn-scala#335).
+  private def hasDependencyCycleTailRec(
+      visit: String,
+      visited: Set[String],
+      dependencies: Map[String, Iterable[String]]): TailRec[Boolean] = {
     if (visited.contains(visit)) {
-      true
+      done(true)
     } else {
-      dependencies.getOrElse(visit, Nil).exists(dependency =>
-        hasDependencyCycle(
-          visit = dependency,
-          visited = visited + visit,
-          dependencies = dependencies
-        )
-      )
+      existsTailRec(
+        dependencies.getOrElse(visit, Nil),
+        (dependency: String) =>
+          tailcall(
+            hasDependencyCycleTailRec(
+              visit = dependency,
+              visited = visited + visit,
+              dependencies = dependencies
+            )))
     }
+  }
+
+  private def existsTailRec[T](it: Iterable[T],
+                               f: T => TailRec[Boolean]): TailRec[Boolean] = {
+    val iterator = it.iterator
+
+    def loop(): TailRec[Boolean] = {
+      if (!iterator.hasNext) {
+        done(false)
+      } else {
+        tailcall(f(iterator.next())).flatMap { found =>
+          if (found) done(true) else loop()
+        }
+      }
+    }
+
+    loop()
   }
 
   private def parseDecision(decision: Decision)(

--- a/src/test/scala/org/camunda/dmn/LongDecisionChainDmnXml.scala
+++ b/src/test/scala/org/camunda/dmn/LongDecisionChainDmnXml.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2022 Camunda Services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.dmn
+
+object LongDecisionChainDmnXml {
+
+  // Builds a linear, acyclic DRG: d0 -> d1 -> ... -> d(n-1), where d(n-1) = 1
+  // and each d(i) = d(i+1) + 1. Mirrors the shape from camunda/dmn-scala#335.
+  def chainDmnXml(decisionCount: Int): String = {
+    val decisions = (0 until decisionCount)
+      .map { i =>
+        if (i == decisionCount - 1) {
+          s"""<decision id="d$i" name="d$i">
+             |<variable id="v$i" name="v$i" />
+             |<literalExpression id="le$i"><text>1</text></literalExpression>
+             |</decision>""".stripMargin
+        } else {
+          val next = i + 1
+          s"""<decision id="d$i" name="d$i">
+             |<variable id="v$i" name="v$i" />
+             |<informationRequirement id="ir$i">
+             |<requiredDecision href="#d$next" />
+             |</informationRequirement>
+             |<literalExpression id="le$i"><text>v$next + 1</text></literalExpression>
+             |</decision>""".stripMargin
+        }
+      }
+      .mkString("\n")
+
+    s"""<?xml version="1.0" encoding="UTF-8"?>
+       |<definitions xmlns="https://www.omg.org/spec/DMN/20191111/MODEL/"
+       |id="Definitions_chain" name="Chain"
+       |namespace="http://camunda.org/schema/1.0/dmn">
+       |$decisions
+       |</definitions>""".stripMargin
+  }
+}

--- a/src/test/scala/org/camunda/dmn/LongDecisionChainEndToEndTest.scala
+++ b/src/test/scala/org/camunda/dmn/LongDecisionChainEndToEndTest.scala
@@ -27,7 +27,7 @@ class LongDecisionChainEndToEndTest extends AnyFlatSpec with Matchers with Decis
   // -> decisionN): deploy (parse), then evaluate, exactly as reported. Kept
   // at the same, smaller count as LongDecisionChainParsingTest (not the
   // evaluator's 10,000) since parsing here goes through the same O(n^2)
-  // cycle-detection walk on an acyclic chain — see Task 4's note.
+  // cycle-detection walk (DmnParser.hasDependencyCycle) on an acyclic chain.
   private val decisionCount = 3000
 
   "A deployed long decision chain" should "parse and evaluate successfully end to end" in {

--- a/src/test/scala/org/camunda/dmn/LongDecisionChainEndToEndTest.scala
+++ b/src/test/scala/org/camunda/dmn/LongDecisionChainEndToEndTest.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright © 2022 Camunda Services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.dmn
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+
+class LongDecisionChainEndToEndTest extends AnyFlatSpec with Matchers with DecisionTest {
+
+  // Same shape as the issue's reported repro (decision1 -> decision2 -> ...
+  // -> decisionN): deploy (parse), then evaluate, exactly as reported. Kept
+  // at the same, smaller count as LongDecisionChainParsingTest (not the
+  // evaluator's 10,000) since parsing here goes through the same O(n^2)
+  // cycle-detection walk on an acyclic chain — see Task 4's note.
+  private val decisionCount = 3000
+
+  "A deployed long decision chain" should "parse and evaluate successfully end to end" in {
+    val xml = LongDecisionChainDmnXml.chainDmnXml(decisionCount)
+    val stream = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))
+    val chain = new ParsedResult(engine.parse(stream)).dmn
+
+    eval(chain, "d0", Map()) should be(decisionCount)
+  }
+}

--- a/src/test/scala/org/camunda/dmn/LongDecisionChainParsingTest.scala
+++ b/src/test/scala/org/camunda/dmn/LongDecisionChainParsingTest.scala
@@ -28,9 +28,11 @@ class LongDecisionChainParsingTest
     with StackSizeTestSupport {
 
   // Deliberately much smaller than the evaluator test's 10,000: the parser's
-  // cycle-detection walk is O(n^2) on an acyclic chain once trampolined (see
-  // the note above this task), so this only needs to be large enough to
-  // reliably overflow a small stack pre-fix, not to stress-test throughput.
+  // cycle-detection walk (DmnParser.hasDependencyCycle) is O(n^2) on an
+  // acyclic chain once trampolined, since `.exists` runs a full DFS from
+  // every start node when none of them find a cycle. This only needs to be
+  // large enough to reliably overflow a small stack pre-fix, not to
+  // stress-test throughput.
   private val decisionCount = 3000
 
   "The DMN parser" should "parse a long chain of acyclic decisions without a StackOverflowError" in {

--- a/src/test/scala/org/camunda/dmn/LongDecisionChainParsingTest.scala
+++ b/src/test/scala/org/camunda/dmn/LongDecisionChainParsingTest.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright © 2022 Camunda Services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.dmn
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+import java.io.ByteArrayInputStream
+import java.nio.charset.StandardCharsets
+
+class LongDecisionChainParsingTest
+    extends AnyFlatSpec
+    with Matchers
+    with DecisionTest
+    with StackSizeTestSupport {
+
+  // Deliberately much smaller than the evaluator test's 10,000: the parser's
+  // cycle-detection walk is O(n^2) on an acyclic chain once trampolined (see
+  // the note above this task), so this only needs to be large enough to
+  // reliably overflow a small stack pre-fix, not to stress-test throughput.
+  private val decisionCount = 3000
+
+  "The DMN parser" should "parse a long chain of acyclic decisions without a StackOverflowError" in {
+    val xml = LongDecisionChainDmnXml.chainDmnXml(decisionCount)
+
+    val parseResult = runWithStackSize(smallStackSize) {
+      val stream = new ByteArrayInputStream(xml.getBytes(StandardCharsets.UTF_8))
+      engine.parse(stream)
+    }
+
+    parseResult.isRight should be(true)
+  }
+}

--- a/src/test/scala/org/camunda/dmn/StackSizeTestSupport.scala
+++ b/src/test/scala/org/camunda/dmn/StackSizeTestSupport.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright © 2022 Camunda Services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.dmn
+
+trait StackSizeTestSupport {
+
+  val smallStackSize: Long = 512 * 1024
+
+  // Runs `body` on a dedicated thread with an explicit stack size, so that
+  // whether a StackOverflowError is thrown does not depend on the JVM's or
+  // CI runner's default thread stack size.
+  def runWithStackSize[T](stackSizeBytes: Long)(body: => T): T = {
+    @volatile var outcome: Either[Throwable, T] = null
+
+    val thread = new Thread(
+      null,
+      () => {
+        outcome = try {
+          Right(body)
+        } catch {
+          case t: Throwable => Left(t)
+        }
+      },
+      "stack-size-test-thread",
+      stackSizeBytes
+    )
+
+    thread.start()
+    thread.join()
+
+    outcome match {
+      case Right(value) => value
+      case Left(error)  => throw error
+    }
+  }
+
+}

--- a/src/test/scala/org/camunda/dmn/StackSizeTestSupport.scala
+++ b/src/test/scala/org/camunda/dmn/StackSizeTestSupport.scala
@@ -23,25 +23,32 @@ trait StackSizeTestSupport {
   // whether a StackOverflowError is thrown does not depend on the JVM's or
   // CI runner's default thread stack size.
   def runWithStackSize[T](stackSizeBytes: Long)(body: => T): T = {
-    @volatile var outcome: Either[Throwable, T] = null
+    @volatile var outcome: Option[Either[Throwable, T]] = None
 
     val thread = new Thread(
       null,
       () => {
-        outcome = try {
+        outcome = Some(try {
           Right(body)
         } catch {
           case t: Throwable => Left(t)
-        }
+        })
       },
       "stack-size-test-thread",
       stackSizeBytes
     )
 
     thread.start()
-    thread.join()
+    try {
+      thread.join()
+    } catch {
+      case _: InterruptedException =>
+        Thread.currentThread().interrupt()
+        throw new RuntimeException("interrupted while waiting for stack-size test thread")
+    }
 
-    outcome match {
+    outcome.getOrElse(
+      Left(new IllegalStateException("thread completed without setting outcome"))) match {
       case Right(value) => value
       case Left(error)  => throw error
     }

--- a/src/test/scala/org/camunda/dmn/evaluation/LongDecisionChainEvaluatorTest.scala
+++ b/src/test/scala/org/camunda/dmn/evaluation/LongDecisionChainEvaluatorTest.scala
@@ -1,0 +1,92 @@
+/*
+ * Copyright © 2022 Camunda Services GmbH (info@camunda.com)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.camunda.dmn.evaluation
+
+import org.camunda.dmn.DecisionTest
+import org.camunda.dmn.DmnEngine.{EvalContext, Failure}
+import org.camunda.dmn.StackSizeTestSupport
+import org.camunda.dmn.parser.{EmptyExpression, ParsedDecision, ParsedDmn, ParsedLiteralExpression}
+import org.camunda.feel.syntaxtree.ValNumber
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+
+class LongDecisionChainEvaluatorTest
+    extends AnyFlatSpec
+    with Matchers
+    with DecisionTest
+    with StackSizeTestSupport {
+
+  private val decisionCount = 10000
+
+  // Reuses an existing, already-parsed test fixture purely to obtain a real
+  // DmnModelInstance to satisfy ParsedDmn's constructor. Its content is
+  // irrelevant here: the stub `eval` below never reads decision.logic
+  // through the real FEEL engine, so this test is isolated to
+  // DecisionEvaluator's own recursion and unaffected by the parser (which
+  // has its own, separately-tested and separately-fixed recursion bug — see
+  // LongDecisionChainParsingTest).
+  private val dummyModel = parse("/requirements/discount.dmn").model
+
+  // Builds a linear chain of ParsedDecision objects, d0 -> d1 -> ... -> d(n-1),
+  // constructed iteratively from the tail (foldRight over a Range is
+  // implemented iteratively in the Scala standard library) so building the
+  // fixture itself can never be the thing that overflows.
+  private def buildChain(decisionCount: Int): ParsedDecision = {
+    val leaf = ParsedDecision(
+      id = s"d${decisionCount - 1}",
+      name = s"d${decisionCount - 1}",
+      logic = ParsedLiteralExpression(EmptyExpression),
+      resultName = s"v${decisionCount - 1}",
+      resultType = None,
+      requiredDecisions = Nil,
+      requiredBkms = Nil
+    )
+
+    (0 until decisionCount - 1).foldRight(leaf) { (i, next) =>
+      ParsedDecision(
+        id = s"d$i",
+        name = s"d$i",
+        logic = ParsedLiteralExpression(EmptyExpression),
+        resultName = s"v$i",
+        resultType = None,
+        requiredDecisions = List(next),
+        requiredBkms = Nil
+      )
+    }
+  }
+
+  private def newEvaluator(): DecisionEvaluator =
+    new DecisionEvaluator(
+      eval = (_, _) => Right(ValNumber(1)),
+      evalBkm = (_, _) => Left(Failure("not required by this test"))
+    )
+
+  "A decision evaluator" should "evaluate a long chain of required decisions without a StackOverflowError" in {
+    val root = buildChain(decisionCount)
+    val evaluator = newEvaluator()
+    val context = EvalContext(
+      dmn = ParsedDmn(dummyModel, root :: Nil),
+      variables = Map.empty,
+      currentElement = root
+    )
+
+    val result = runWithStackSize(smallStackSize) {
+      evaluator.eval(root, context)
+    }
+
+    result should be(Right(ValNumber(1)))
+  }
+}


### PR DESCRIPTION
## Summary

Backport of #360 to the `stable/1.10` release line, needed for camunda/camunda's `stable/8.8`, which is currently pinned to `dmn-scala` 1.10.3.

Fixes #335: `DecisionEvaluator.evalDecision`/`evalRequiredDecisions` and `DmnParser.hasDependencyCycle` both recurse one JVM stack frame per link in a decision-requirements chain, causing an uncaught `StackOverflowError` on long chains — one at evaluation time, one (independently) at parse/deploy time on any long *acyclic* chain. Both trampolined via `scala.util.control.TailCalls`, no behavior change (same evaluation order, same short-circuit-on-first-failure, no memoization).

Cherry-picked cleanly from `main` (#360) — the three affected files (`DecisionEvaluator.scala`, `FunctionalHelper.scala`, `DmnParser.scala`) were byte-identical between `stable/1.10` and `main` at the point #360 was based on, so this is the same fix, same tests, same review-round follow-ups, no adaptation needed. Full suite passes on this branch.

## Related

- Fixes #335
- Backport of #360 (merged to `main`)
- Sibling backport: #362 (`stable/1.11`)